### PR TITLE
added keyboardShouldPersistTaps='handled' to HOC

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -327,6 +327,7 @@ function listenToKeyboardEvents(ScrollableComponent: React$Component) {
         <ScrollableComponent
           ref={this._handleRef}
           keyboardDismissMode='interactive'
+          keyboardShouldPersistTaps='handled'
           contentInset={{ bottom: this.state.keyboardSpace }}
           automaticallyAdjustContentInsets={false}
           showsVerticalScrollIndicator={true}


### PR DESCRIPTION
This is so users don't have to tap twice (once first to dismiss), when attempting to tap Touchables while keyboard is open.